### PR TITLE
Refactor 300w_lp dataset to add metadata and more tensorflow datasets

### DIFF
--- a/giskard_vision/core/dataloaders/tfds.py
+++ b/giskard_vision/core/dataloaders/tfds.py
@@ -1,0 +1,152 @@
+import numpy as np
+from typing import Any, Dict, List, Optional
+
+from giskard_vision.core.dataloaders.base import DataIteratorBase
+from giskard_vision.core.dataloaders.meta import MetaData
+from giskard_vision.landmark_detection.types import Types
+from giskard_vision.utils.errors import GiskardImportError
+
+
+def flatten_dict_exclude_wrapper(d: Dict[str, Any], excludes: List[str] = [], parent_key: str = "", sep: str = "_", flat_np_array: bool = False) -> Dict[str, Any]:
+    """
+    Flattens a nested dictionary without the specified keys.
+
+    Args:
+        d (Dict[str, Any]): The dictionary to flatten.
+        excludes (List[str]): Keys to exclude from the flattened dictionary.
+        parent_key (str): The base key string for the flattened keys.
+        sep (str): The separator between keys.
+
+    Returns:
+        Dict[str, Any]: The flattened dictionary.
+    """
+    items = {}
+    for k, v in d.items():
+        if k in excludes:
+            continue
+        items.update(flatten_dict({k: v}, parent_key=parent_key, sep=sep, flat_np_array=flat_np_array).items())
+
+    return items
+
+
+def flatten_dict(d: Dict[str, Any], parent_key: str = "", sep: str = "_", flat_np_array: bool = False) -> Dict[str, Any]:
+    """
+    Flattens a nested dictionary.
+
+    Args:
+        d (Dict[str, Any]): The dictionary to flatten.
+        parent_key (str): The base key string for the flattened keys.
+        sep (str): The separator between keys.
+        flat_np_array (bool): Flag to flatten numpy arrays. Default is `False`.
+
+    Returns:
+        Dict[str, Any]: The flattened dictionary.
+    """
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        elif isinstance(v, list) or (isinstance(v, np.ndarray) and flat_np_array):
+            for i, item in enumerate(v):
+                items.extend(flatten_dict({f"{new_key}_{i}": item}, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
+
+
+class DataLoaderTensorFlowDatasets(DataIteratorBase):
+    """
+    A generic data loader for the Tensorflow Datasets, extending the DataIteratorBase class.
+
+    Attributes:
+        dataset_split (str): Specifies the dataset split, defaulting to "train".
+        ds (Any): The loaded dataset split.
+        info (Any): Information about the loaded dataset.
+        meta_exclude_keys (List[str]): Keys to exclude from metadata.
+        splits (Any): The dataset splits in the specified dataset.
+
+    Args:
+        tfds_id (str): The ID of the Tensorflow dataset.
+        tfds_split (str): The dataset split to load, defaulting to "train".
+        name (Optional[str]): Name of the data loader instance.
+        data_dir (Optional[str]): Directory path for loading the dataset.
+
+    Raises:
+        GiskardImportError: If there are missing dependencies such as TensorFlow, TensorFlow-Datasets, or SciPy.
+    """
+
+    def __init__(self, tfds_id: str, tfds_split: str = "train", name: Optional[str] = None, data_dir: Optional[str] = None) -> None:
+        """
+        Initializes the Tensorflow Datasets instance.
+
+        Args:
+            name (Optional[str]): Name of the data loader instance.
+            data_dir (Optional[str]): Directory path for loading the dataset.
+
+        Raises:
+            GiskardImportError: If there are missing dependencies such as TensorFlow, TensorFlow-Datasets, or SciPy.
+        """
+        super().__init__(name)
+
+        try:
+            import scipy.io  # noqa
+            import tensorflow  # noqa
+            import tensorflow_datasets as tfds
+        except ImportError as e:
+            raise GiskardImportError(["tensorflow", "tensorflow-datasets", "scipy"]) from e
+
+        # Exclude keys from metadata
+        self.meta_exclude_keys = []
+
+        self.dataset_split = tfds_split
+        self.splits, self.info = tfds.load(tfds_id, data_dir=data_dir, with_info=True)
+        self.ds = self.splits[self.dataset_split]
+        self._idx_sampler = list(range(len(self)))
+
+    def __len__(self) -> int:
+        """
+        Returns the total number of examples in the specified dataset split.
+
+        Returns:
+            int: Total number of examples in the dataset split.
+        """
+        return self.info.splits[self.dataset_split].num_examples
+
+    def get_row(self, idx: int) -> Dict[str, Any]:
+        """
+        Returns the raw row at the specified index in the specified dataset split.
+
+        Returns:
+            int: Total number of examples in the dataset split.
+        """
+        return self.ds.skip(idx).as_numpy_iterator().next()
+
+    def get_meta(self, idx: int) -> Optional[Types.meta]:
+        """
+        Returns metadata associated with the image at the specified index.
+
+        Args:
+            idx (int): Index of the image.
+
+        Returns:
+            Optional[Types.meta]: Metadata associated with the image, currently None.
+        """
+        row = self.get_row(idx)
+
+        flat_meta = flatten_dict_exclude_wrapper(row, excludes=self.meta_exclude_keys, flat_np_array=True)
+
+        return MetaData(
+            data=flat_meta,
+            categories=flat_meta.keys(),
+        )
+
+    @property
+    def idx_sampler(self):
+        """
+        Gets the index sampler for the data loader.
+
+        Returns:
+            List: List of image indices for data loading.
+        """
+        return self._idx_sampler

--- a/giskard_vision/core/dataloaders/tfds.py
+++ b/giskard_vision/core/dataloaders/tfds.py
@@ -1,63 +1,10 @@
-from typing import Any, Dict, List, Optional
-
-import numpy as np
+from typing import Any, Dict, Optional
 
 from giskard_vision.core.dataloaders.base import DataIteratorBase
 from giskard_vision.core.dataloaders.meta import MetaData
+from giskard_vision.core.dataloaders.utils import flatten_dict_exclude_wrapper
 from giskard_vision.landmark_detection.types import Types
 from giskard_vision.utils.errors import GiskardImportError
-
-
-def flatten_dict_exclude_wrapper(
-    d: Dict[str, Any], excludes: List[str] = [], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
-) -> Dict[str, Any]:
-    """
-    Flattens a nested dictionary without the specified keys.
-
-    Args:
-        d (Dict[str, Any]): The dictionary to flatten.
-        excludes (List[str]): Keys to exclude from the flattened dictionary.
-        parent_key (str): The base key string for the flattened keys.
-        sep (str): The separator between keys.
-
-    Returns:
-        Dict[str, Any]: The flattened dictionary.
-    """
-    items = {}
-    for k, v in d.items():
-        if k in excludes:
-            continue
-        items.update(flatten_dict({k: v}, parent_key=parent_key, sep=sep, flat_np_array=flat_np_array).items())
-
-    return items
-
-
-def flatten_dict(
-    d: Dict[str, Any], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
-) -> Dict[str, Any]:
-    """
-    Flattens a nested dictionary.
-
-    Args:
-        d (Dict[str, Any]): The dictionary to flatten.
-        parent_key (str): The base key string for the flattened keys.
-        sep (str): The separator between keys.
-        flat_np_array (bool): Flag to flatten numpy arrays. Default is `False`.
-
-    Returns:
-        Dict[str, Any]: The flattened dictionary.
-    """
-    items = []
-    for k, v in d.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
-        elif isinstance(v, list) or (isinstance(v, np.ndarray) and flat_np_array):
-            for i, item in enumerate(v):
-                items.extend(flatten_dict({f"{new_key}_{i}": item}, sep=sep).items())
-        else:
-            items.append((new_key, v))
-    return dict(items)
 
 
 class DataLoaderTensorFlowDatasets(DataIteratorBase):

--- a/giskard_vision/core/dataloaders/tfds.py
+++ b/giskard_vision/core/dataloaders/tfds.py
@@ -1,5 +1,6 @@
-import numpy as np
 from typing import Any, Dict, List, Optional
+
+import numpy as np
 
 from giskard_vision.core.dataloaders.base import DataIteratorBase
 from giskard_vision.core.dataloaders.meta import MetaData
@@ -7,7 +8,9 @@ from giskard_vision.landmark_detection.types import Types
 from giskard_vision.utils.errors import GiskardImportError
 
 
-def flatten_dict_exclude_wrapper(d: Dict[str, Any], excludes: List[str] = [], parent_key: str = "", sep: str = "_", flat_np_array: bool = False) -> Dict[str, Any]:
+def flatten_dict_exclude_wrapper(
+    d: Dict[str, Any], excludes: List[str] = [], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
+) -> Dict[str, Any]:
     """
     Flattens a nested dictionary without the specified keys.
 
@@ -29,7 +32,9 @@ def flatten_dict_exclude_wrapper(d: Dict[str, Any], excludes: List[str] = [], pa
     return items
 
 
-def flatten_dict(d: Dict[str, Any], parent_key: str = "", sep: str = "_", flat_np_array: bool = False) -> Dict[str, Any]:
+def flatten_dict(
+    d: Dict[str, Any], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
+) -> Dict[str, Any]:
     """
     Flattens a nested dictionary.
 
@@ -76,7 +81,9 @@ class DataLoaderTensorFlowDatasets(DataIteratorBase):
         GiskardImportError: If there are missing dependencies such as TensorFlow, TensorFlow-Datasets, or SciPy.
     """
 
-    def __init__(self, tfds_id: str, tfds_split: str = "train", name: Optional[str] = None, data_dir: Optional[str] = None) -> None:
+    def __init__(
+        self, tfds_id: str, tfds_split: str = "train", name: Optional[str] = None, data_dir: Optional[str] = None
+    ) -> None:
         """
         Initializes the Tensorflow Datasets instance.
 

--- a/giskard_vision/core/dataloaders/utils.py
+++ b/giskard_vision/core/dataloaders/utils.py
@@ -1,0 +1,55 @@
+from typing import Any, Dict, List
+
+import numpy as np
+
+
+def flatten_dict_exclude_wrapper(
+    d: Dict[str, Any], excludes: List[str] = [], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
+) -> Dict[str, Any]:
+    """
+    Flattens a nested dictionary without the specified keys.
+
+    Args:
+        d (Dict[str, Any]): The dictionary to flatten.
+        excludes (List[str]): Keys to exclude from the flattened dictionary.
+        parent_key (str): The base key string for the flattened keys.
+        sep (str): The separator between keys.
+
+    Returns:
+        Dict[str, Any]: The flattened dictionary.
+    """
+    items = {}
+    for k, v in d.items():
+        if k in excludes:
+            continue
+        items.update(flatten_dict({k: v}, parent_key=parent_key, sep=sep, flat_np_array=flat_np_array).items())
+
+    return items
+
+
+def flatten_dict(
+    d: Dict[str, Any], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
+) -> Dict[str, Any]:
+    """
+    Flattens a nested dictionary.
+
+    Args:
+        d (Dict[str, Any]): The dictionary to flatten.
+        parent_key (str): The base key string for the flattened keys.
+        sep (str): The separator between keys.
+        flat_np_array (bool): Flag to flatten numpy arrays. Default is `False`.
+
+    Returns:
+        Dict[str, Any]: The flattened dictionary.
+    """
+    items = []
+    for k, v in d.items():
+        new_key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        elif isinstance(v, list) or (isinstance(v, np.ndarray) and flat_np_array):
+            for i, item in enumerate(v):
+                items.extend(flatten_dict({f"{new_key}_{i}": item}, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)

--- a/giskard_vision/image_classification/dataloaders/loaders.py
+++ b/giskard_vision/image_classification/dataloaders/loaders.py
@@ -1,0 +1,78 @@
+from typing import Optional
+import numpy as np
+
+from giskard_vision.core.dataloaders.tfds import DataLoaderTensorFlowDatasets
+
+
+class DataLoaderGeirhosConflictStimuli(DataLoaderTensorFlowDatasets):
+    """
+    A data loader for the `geirhos_conflict_stimuli` dataset, extending the DataLoaderTensorFlowDatasets class.
+
+    Attributes:
+        label_key (str): Key for accessing `shape_label` in the dataset.
+        image_key (str): Key for accessing images in the dataset.
+        dataset_split (str): Specifies the dataset split, defaulting to "train".
+
+    Args:
+        name (Optional[str]): Name of the data loader instance.
+        data_dir (Optional[str]): Directory path for loading the dataset.
+
+    Raises:
+        GiskardImportError: If there are missing dependencies such as TensorFlow, TensorFlow-Datasets, or SciPy.
+    """
+
+    label_key = "shape_label"
+    image_key = "image"
+    dataset_split = "test"
+
+    def __init__(self, name: Optional[str] = None, data_dir: Optional[str] = None) -> None:
+        """
+        Initializes the GeirhosConflictStimuli instance.
+
+        Args:
+            name (Optional[str]): Name of the data loader instance.
+            data_dir (Optional[str]): Directory path for loading the dataset.
+
+        Raises:
+            GiskardImportError: If there are missing dependencies such as TensorFlow, TensorFlow-Datasets, or SciPy.
+        """
+        super().__init__("geirhos_conflict_stimuli", self.dataset_split, name, data_dir)
+
+        self.meta_exclude_keys.extend([
+            # Exclude input and output
+            self.image_key,
+            self.label_key,
+
+            # Exclude other info, see https://www.tensorflow.org/datasets/catalog/geirhos_conflict_stimuli
+            "file_name",
+            "shape_imagenet_labels",
+            "texture_imagenet_labels",
+        ])
+
+    def get_image(self, idx: int) -> np.ndarray:
+        """
+        Retrieves the image at the specified index in the dataset.
+
+        Args:
+            idx (int): Index of the image to retrieve.
+
+        Returns:
+            np.ndarray: The image data.
+        """
+        return self.get_row(idx)[self.image_key]
+
+    def get_labels(self, idx: int) -> Optional[np.ndarray]:
+        """
+        Retrieves shape label of the image at the specified index.
+
+        Args:
+            idx (int): Index of the image.
+
+        Returns:
+            Optional[np.ndarray]: shape label.
+        """
+        row = self.get_row(idx)
+
+        return np.array([row[self.label_key]])
+
+

--- a/giskard_vision/image_classification/dataloaders/loaders.py
+++ b/giskard_vision/image_classification/dataloaders/loaders.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import numpy as np
 
 from giskard_vision.core.dataloaders.tfds import DataLoaderTensorFlowDatasets
@@ -38,16 +39,17 @@ class DataLoaderGeirhosConflictStimuli(DataLoaderTensorFlowDatasets):
         """
         super().__init__("geirhos_conflict_stimuli", self.dataset_split, name, data_dir)
 
-        self.meta_exclude_keys.extend([
-            # Exclude input and output
-            self.image_key,
-            self.label_key,
-
-            # Exclude other info, see https://www.tensorflow.org/datasets/catalog/geirhos_conflict_stimuli
-            "file_name",
-            "shape_imagenet_labels",
-            "texture_imagenet_labels",
-        ])
+        self.meta_exclude_keys.extend(
+            [
+                # Exclude input and output
+                self.image_key,
+                self.label_key,
+                # Exclude other info, see https://www.tensorflow.org/datasets/catalog/geirhos_conflict_stimuli
+                "file_name",
+                "shape_imagenet_labels",
+                "texture_imagenet_labels",
+            ]
+        )
 
     def get_image(self, idx: int) -> np.ndarray:
         """
@@ -74,5 +76,3 @@ class DataLoaderGeirhosConflictStimuli(DataLoaderTensorFlowDatasets):
         row = self.get_row(idx)
 
         return np.array([row[self.label_key]])
-
-

--- a/giskard_vision/landmark_detection/dataloaders/loaders.py
+++ b/giskard_vision/landmark_detection/dataloaders/loaders.py
@@ -6,35 +6,9 @@ import cv2
 import numpy as np
 
 from giskard_vision.core.dataloaders.meta import MetaData
-from giskard_vision.utils.errors import GiskardImportError
+from giskard_vision.core.dataloaders.tfds import DataLoaderTensorFlowDatasets
 
-from ..types import Types
-from .base import DataIteratorBase, DataLoaderBase
-
-
-def flatten_dict(d: Dict[str, Any], parent_key: str = "", sep: str = "_") -> Dict[str, Any]:
-    """
-    Flattens a nested dictionary.
-
-    Args:
-        d (Dict[str, Any]): The dictionary to flatten.
-        parent_key (str): The base key string for the flattened keys.
-        sep (str): The separator between keys.
-
-    Returns:
-        Dict[str, Any]: The flattened dictionary.
-    """
-    items = []
-    for k, v in d.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
-        elif isinstance(v, list):
-            for i, item in enumerate(v):
-                items.extend(flatten_dict({f"{new_key}_{i}": item}, sep=sep).items())
-        else:
-            items.append((new_key, v))
-    return dict(items)
+from .base import DataLoaderBase
 
 
 class DataLoader300W(DataLoaderBase):
@@ -260,9 +234,9 @@ class DataLoaderFFHQ(DataLoaderBase):
         raise NotImplementedError("Should not be called for FFHQ")
 
 
-class DataLoader300WLP(DataIteratorBase):
+class DataLoader300WLP(DataLoaderTensorFlowDatasets):
     """
-    A data loader for the 300W-LP dataset, extending the DataIteratorBase class.
+    A data loader for the 300W-LP dataset, extending the DataLoaderTensorFlowDatasets class.
 
     Attributes:
         landmarks_key (str): Key for accessing 2D landmarks in the dataset.
@@ -292,27 +266,19 @@ class DataLoader300WLP(DataIteratorBase):
         Raises:
             GiskardImportError: If there are missing dependencies such as TensorFlow, TensorFlow-Datasets, or SciPy.
         """
-        super().__init__(name)
+        super().__init__("the300w_lp", self.dataset_split, name, data_dir)
 
-        try:
-            import scipy.io  # noqa
-            import tensorflow  # noqa
-            import tensorflow_datasets as tfds
-        except ImportError as e:
-            raise GiskardImportError(["tensorflow", "tensorflow-datasets", "scipy"]) from e
+        self.meta_exclude_keys.extend([
+            # Exclude input and output
+            self.image_key,
+            self.landmarks_key,
 
-        self.splits, self.info = tfds.load("the300w_lp", data_dir=data_dir, with_info=True)
-        self.ds = self.splits[self.dataset_split]
-        self._idx_sampler = list(range(len(self)))
-
-    def __len__(self) -> int:
-        """
-        Returns the total number of examples in the specified dataset split.
-
-        Returns:
-            int: Total number of examples in the dataset split.
-        """
-        return self.info.splits[self.dataset_split].num_examples
+            # Exclude other info, see https://www.tensorflow.org/datasets/catalog/the300w_lp
+            "landmarks_3d",
+            "landmarks_origin",
+            "shape_params",     # 199 shape parameters
+            "tex_params",       # 199 texture parameters
+        ])
 
     def get_image(self, idx: int) -> np.ndarray:
         """
@@ -324,7 +290,7 @@ class DataLoader300WLP(DataIteratorBase):
         Returns:
             np.ndarray: The image data.
         """
-        return self.ds.skip(idx).as_numpy_iterator().next()[self.image_key]
+        return self.get_row(idx)[self.image_key]
 
     def get_labels(self, idx: int) -> Optional[np.ndarray]:
         """
@@ -336,32 +302,10 @@ class DataLoader300WLP(DataIteratorBase):
         Returns:
             Optional[np.ndarray]: Normalized 2D landmarks, or None if not available.
         """
-        row = self.ds.skip(idx).as_numpy_iterator().next()
+        row = self.get_row(idx)
 
         # Marks are normalized to [0, 1]
         normalized_marks = row[self.landmarks_key]
 
         # Compute the marks
         return normalized_marks * row[self.image_key].shape[:2]
-
-    def get_meta(self, idx: int) -> Optional[Types.meta]:
-        """
-        Returns metadata associated with the image at the specified index.
-
-        Args:
-            idx (int): Index of the image.
-
-        Returns:
-            Optional[Types.meta]: Metadata associated with the image, currently None.
-        """
-        return None
-
-    @property
-    def idx_sampler(self):
-        """
-        Gets the index sampler for the data loader.
-
-        Returns:
-            List: List of image indices for data loading.
-        """
-        return self._idx_sampler

--- a/giskard_vision/landmark_detection/dataloaders/loaders.py
+++ b/giskard_vision/landmark_detection/dataloaders/loaders.py
@@ -7,36 +7,9 @@ import numpy as np
 
 from giskard_vision.core.dataloaders.meta import MetaData
 from giskard_vision.core.dataloaders.tfds import DataLoaderTensorFlowDatasets
+from giskard_vision.core.dataloaders.utils import flatten_dict
 
 from .base import DataLoaderBase
-
-
-def flatten_dict(
-    d: Dict[str, Any], parent_key: str = "", sep: str = "_", flat_np_array: bool = False
-) -> Dict[str, Any]:
-    """
-    Flattens a nested dictionary.
-
-    Args:
-        d (Dict[str, Any]): The dictionary to flatten.
-        parent_key (str): The base key string for the flattened keys.
-        sep (str): The separator between keys.
-        flat_np_array (bool): Flag to flatten numpy arrays. Default is `False`.
-
-    Returns:
-        Dict[str, Any]: The flattened dictionary.
-    """
-    items = []
-    for k, v in d.items():
-        new_key = f"{parent_key}{sep}{k}" if parent_key else k
-        if isinstance(v, dict):
-            items.extend(flatten_dict(v, new_key, sep=sep).items())
-        elif isinstance(v, list) or (isinstance(v, np.ndarray) and flat_np_array):
-            for i, item in enumerate(v):
-                items.extend(flatten_dict({f"{new_key}_{i}": item}, sep=sep).items())
-        else:
-            items.append((new_key, v))
-    return dict(items)
 
 
 class DataLoader300W(DataLoaderBase):


### PR DESCRIPTION
- Refactor the300w_lp dataset to contain flattened metadata (added an option to flatten np array as well)
- Wrap [geirhos_conflict_stimuli dataset](https://www.tensorflow.org/datasets/catalog/geirhos_conflict_stimuli) for image classification:
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/204b6859-604d-4eed-92c3-ed870d4332c8">

The 300w_lp dataset can be tested with https://github.com/Giskard-AI/giskard-vision/pull/37 with rich metadata:

```
{'color_params_0': 0.9529692,
 'color_params_1': 0.9108704,
 'color_params_2': 0.7511317,
 'color_params_3': -0.15245196,
 'color_params_4': -0.07224317,
 'color_params_5': -0.042683303,
 'color_params_6': 1.0,
 'exp_params_0': -1.8980943,
 'exp_params_1': 2.0162644,
 'exp_params_2': -0.21372202,
 'exp_params_3': 0.37390882,
 'exp_params_4': 0.17389908,
 'exp_params_5': -0.019172015,
 'exp_params_6': 0.10593662,
 'exp_params_7': -0.2973795,
 'exp_params_8': -0.042247314,
 'exp_params_9': -0.2033185,
 'exp_params_10': -0.01559021,
 'exp_params_11': 0.012607691,
 'exp_params_12': -0.01533393,
 'exp_params_13': 0.05862778,
 'exp_params_14': -0.09072945,
 'exp_params_15': 4.416328e-05,
 'exp_params_16': 0.040819146,
 'exp_params_17': 0.0188645,
 'exp_params_18': 0.0061222604,
 'exp_params_19': -0.00477802,
 'exp_params_20': 0.036543,
 'exp_params_21': 0.040243164,
 'exp_params_22': 0.065363064,
 'exp_params_23': 0.0037580468,
 'exp_params_24': 0.02490677,
 'exp_params_25': 0.0076197227,
 'exp_params_26': 0.02863932,
 'exp_params_27': -0.028057478,
 'exp_params_28': 0.0035590131,
 'illum_params_0': 1.0763478,
 'illum_params_1': 1.0480487,
 'illum_params_2': 1.0694063,
 'illum_params_3': 0.28690505,
 'illum_params_4': 0.28800267,
 'illum_params_5': 0.19409882,
 'illum_params_6': 0.84837306,
 'illum_params_7': 1.5241023,
 'illum_params_8': 0.0,
 'illum_params_9': 20.0,
 'pose_params_0': 0.20616715,
 'pose_params_1': 0.53957874,
 'pose_params_2': -0.20789813,
 'pose_params_3': 263.1852,
 'pose_params_4': 156.2522,
 'pose_params_5': -90.430405,
 'pose_params_6': 0.0012699001,
 'roi_0': -89.0,
 'roi_1': -206.0,
 'roi_2': 501.0,
 'roi_3': 384.0}
```
